### PR TITLE
there is no __int64 in standard C++

### DIFF
--- a/include/ObjectDataField.h
+++ b/include/ObjectDataField.h
@@ -18,10 +18,10 @@ public:
     ObjectDataField(
             Document *document,
             void *obj,
-            BRLCAD::Vector3D (T::*getter)(unsigned __int64) const,
-            void (T::*setter)(unsigned __int64, const BRLCAD::Vector3D&),
-            unsigned __int64 start,
-            unsigned __int64 count,
+            BRLCAD::Vector3D (T::*getter)(size_t) const,
+            void (T::*setter)(size_t, const BRLCAD::Vector3D&),
+            size_t start,
+            size_t count,
             const QStringList & indices,
             QString title
     ) : QVBoxWidget() , document(document) {
@@ -75,10 +75,10 @@ public:
     ObjectDataField(
             Document *document,
             void *obj,
-            BRLCAD::Vector3D (T::*getter)(unsigned __int64) const,
-            void (T::*setter)(unsigned __int64, BRLCAD::Vector3D&),
-            unsigned __int64 start,
-            unsigned __int64 count,
+            BRLCAD::Vector3D (T::*getter)(size_t) const,
+            void (T::*setter)(size_t, BRLCAD::Vector3D&),
+            size_t start,
+            size_t count,
             const QStringList & indices,
             QString title
     ) : QVBoxWidget() , document(document) {

--- a/include/ObjectDataTable.h
+++ b/include/ObjectDataTable.h
@@ -12,7 +12,7 @@ class ObjectDataTable : public QVBoxWidget {
 public:
     explicit ObjectDataTable(QWidget* parent = nullptr);
 
-    template <typename T> void initialize(BRLCAD::Vector3D (T::*function)(unsigned __int64)const){
+    template <typename T> void initialize(BRLCAD::Vector3D (T::*function)(size_t)const){
 
     }
 


### PR DESCRIPTION
as far as I know, __int 64 is MS Visual Studio specific; replaced it by
the type used in the BRL-CAD C++ core interface