### PR TITLE
standard std::exception constructor does not know a string parameter

### DIFF
--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -11,7 +11,7 @@ Document::Document(const int documentId, const QString *filePath) : documentId(d
     if (filePath != nullptr) {
         if (!database->Load(filePath->toUtf8().data()))
         {
-            throw std::exception("Failed to open file");
+            throw std::runtime_error("Failed to open file");
         }
     }
 


### PR DESCRIPTION
used std::runtime_error instead, which reflects better the kind of
error: errors that are due to events beyond the scope of the program and
can not be easily predicted