### PR TITLE
fixes for gcc on Linux

### DIFF
--- a/include/DisplayGrid.h
+++ b/include/DisplayGrid.h
@@ -6,7 +6,7 @@
 #include <include/QVBoxWidget.h>
 #include <include/Document.h>
 #include <include/Display.h>
-#include <QSplitter.h>
+#include <QSplitter>
 
 class Display;
 

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -10,6 +10,7 @@
 #include "QSSPreprocessor.h"
 #include <QStatusBar>
 #include <QMenuBar>
+#include <QComboBox>
 
 class Document;
 

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -82,6 +82,8 @@ const double * getLeafMatrix(BRLCAD::Combination::TreeNode& node, const QString&
             return nullptr;
         }
     }
+
+    return nullptr;
 }
 
 void setLeafMatrix(BRLCAD::Combination::TreeNode& node, const QString& name, double * matrix) {


### PR DESCRIPTION
one again some adaptions from the Linux build:
- missing header
- default Qt header name
- default function return (which never should be reached)